### PR TITLE
Handle symbolic links correctly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export function entryTrees (trgPath: string, deps: number) {
     let tmpFiles: Array<object> = [];
     beforSortFiles.forEach(target => {
         let fullPath = path.join(trgPath, target.toString());
-        if (fs.statSync(fullPath).isDirectory()) {
+        if (fs.lstatSync(fullPath).isDirectory()) {
             paths.push(target);
         } else {
             tmpFiles.push(target);
@@ -55,7 +55,7 @@ export function entryTrees (trgPath: string, deps: number) {
         let fullPath = path.join(trgPath, item.toString());
         let pipe = paths.indexOf(item) === paths.length - 1 ? '┗ ' : '┣ ';
         
-        if (fs.statSync(fullPath).isDirectory()) {
+        if (fs.lstatSync(fullPath).isDirectory()) {
             treeText += format(deps, pipe, '<span class="t-icon" name="icons">📂</span>' + item.toString());
             treeText += entryTrees(fullPath, deps + 1);
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,10 @@ export function entryTrees (trgPath: string, deps: number) {
         let fullPath = path.join(trgPath, item.toString());
         let pipe = paths.indexOf(item) === paths.length - 1 ? '┗ ' : '┣ ';
         
-        if (fs.lstatSync(fullPath).isDirectory()) {
+        if (fs.lstatSync(fullPath).isSymbolicLink()) {
+            treeText += format(deps, pipe, '<span class="t-icon" name="icons">🔗</span>' + item.toString());
+        }
+        else if (fs.lstatSync(fullPath).isDirectory()) {
             treeText += format(deps, pipe, '<span class="t-icon" name="icons">📂</span>' + item.toString());
             treeText += entryTrees(fullPath, deps + 1);
         } else {


### PR DESCRIPTION
This PR does 2 things:

1. Fixes #4 by using `lstatSync` (which handles symbolic links) instead of `statSync`. `lstatSync(...).isDirectory()` will return `false` for symbolic links, so they will then be treated as files.
2. Detects symbolic links with `lstatSync(...).isSymbolicLink()` and replaces the file symbol (📜) with a link symbol (🔗).

If you do not think 2 is desirable I can revert that change and just treat symbolic links as files.